### PR TITLE
Promisify adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1486,6 +1486,15 @@
         "type-detect": "4.0.8"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "1.0.2"
+      }
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/register": "^7.0.0",
     "babel-plugin-istanbul": "^5.0.1",
     "chai": "^4.1.2",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^5.6.0",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-markdown": "^1.0.0-beta.8",

--- a/src/index.js
+++ b/src/index.js
@@ -65,17 +65,19 @@ const ClientStorageAdapter = ({ storage }) => {
         },
 
         hasItem(key) {
-            return storage.hasOwnProperty(key);
+            return Promise.resolve(storage.hasOwnProperty(key));
         },
 
         removeItem(key) {
-            if (this.hasItem(key)) {
-                storage.removeItem(key);
+            return this.hasItem(key).then((result) => {
+                if (result) {
+                    storage.removeItem(key);
 
-                return !this.hasItem(key);
-            }
+                    return !this.hasItem(key).then((result) => result);
+                }
 
-            return false;
+                return false
+            });
         }
     };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -73,10 +73,10 @@ const ClientStorageAdapter = ({ storage }) => {
                 if (result) {
                     storage.removeItem(key);
 
-                    return !this.hasItem(key).then((result) => result);
+                    return this.hasItem(key).then((result) => !result);
                 }
 
-                return false
+                return false;
             });
         }
     };

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const ClientStorageAdapter = ({ storage }) => {
 
             storage.setItem(key, stringifiedItem);
 
-            return item;
+            return Promise.resolve(item);
         },
 
         getItem(key) {
@@ -38,26 +38,23 @@ const ClientStorageAdapter = ({ storage }) => {
             const item = this.getItem(key);
 
             if (!item) {
-                return undefined;
+                return Promise.resolve(undefined);
             }
 
             const currentExtra = item.extra;
             const combinedExtra = Object.assign({}, currentExtra, extra);
-            const newItem = this.setItem(key, item.value, combinedExtra);
 
-            return newItem.extra;
+            return this.setItem(key, item.value, combinedExtra).then((newItem) => newItem.extra);
         },
 
         setExtra(key, extra) {
             const item = this.getItem(key);
 
             if (!item) {
-                return undefined;
+                return Promise.resolve(undefined);
             }
 
-            const newItem = this.setItem(key, item.value, extra);
-
-            return newItem.extra;
+            return this.setItem(key, item.value, extra).then((newItem) => newItem.extra);
         },
 
         getExtra(key) {

--- a/src/index.js
+++ b/src/index.js
@@ -30,37 +30,38 @@ const ClientStorageAdapter = ({ storage }) => {
 
         getItem(key) {
             const stringifiedItem = storage.getItem(key);
+            const result = stringifiedItem === null ? undefined : JSON.parse(stringifiedItem);
 
-            return stringifiedItem === null ? undefined : JSON.parse(stringifiedItem);
+            return Promise.resolve(result);
         },
 
         addExtra(key, extra) {
-            const item = this.getItem(key);
+            return this.getItem(key).then((item) => {
+                if (!item) {
+                    return undefined;
+                }
 
-            if (!item) {
-                return Promise.resolve(undefined);
-            }
+                const currentExtra = item.extra;
+                const combinedExtra = Object.assign({}, currentExtra, extra);
 
-            const currentExtra = item.extra;
-            const combinedExtra = Object.assign({}, currentExtra, extra);
-
-            return this.setItem(key, item.value, combinedExtra).then((newItem) => newItem.extra);
+                return this.setItem(key, item.value, combinedExtra).then((newItem) => newItem.extra);
+            });
         },
 
         setExtra(key, extra) {
-            const item = this.getItem(key);
+            return this.getItem(key).then((item) => {
+                if (!item) {
+                    return undefined;
+                }
 
-            if (!item) {
-                return Promise.resolve(undefined);
-            }
-
-            return this.setItem(key, item.value, extra).then((newItem) => newItem.extra);
+                return this.setItem(key, item.value, extra).then((newItem) => newItem.extra);
+            });
         },
 
         getExtra(key) {
-            const item = this.getItem(key);
-
-            return item ? item.extra : undefined;
+            return this.getItem(key).then((item) => {
+                return item ? item.extra : undefined;
+            });
         },
 
         hasItem(key) {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const ClientStorageAdapter = ({ storage }) => {
 
     return {
         buildKey(key) {
-            return key;
+            return Promise.resolve(key);
         },
 
         setItem(key, value, extra = {}) {

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -1,11 +1,13 @@
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import throwOnWarnings from './helpers/throwOnWarnings';
 
 throwOnWarnings(console);
 
 chai.use(sinonChai);
+chai.use(chaiAsPromised);
 
 global.window = {
     Storage: {}

--- a/test/unit/src/index.test.js
+++ b/test/unit/src/index.test.js
@@ -44,12 +44,6 @@ describe('clientStorageAdapter', () => {
         getItemStub.resetHistory();
         hasOwnPropertyStub.resetHistory();
         storageDummy.removeItem.resetHistory();
-
-        sandbox.spy(JSON, 'stringify');
-    });
-
-    afterEach(() => {
-        sandbox.restore();
     });
 
     describe('storage validation', () => {
@@ -90,11 +84,18 @@ describe('clientStorageAdapter', () => {
     });
 
     describe('setItem', () => {
-        it('should store and resolve with item', (done) => {
+        beforeEach(() => {
+            sandbox.spy(JSON, 'stringify');
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('should store an item', (done) => {
             const adapter = createClientStorageAdapter(defaultOptions);
 
             adapter.setItem(FOO_KEY, FOO_VALUE).then((item) => {
-                expect(item).to.deep.eq(fooItem);
                 expect(storageDummy.setItem)
                     .to.have.been.calledWith(FOO_KEY, fooItemStringified)
                     .to.have.been.calledOnce;
@@ -106,12 +107,17 @@ describe('clientStorageAdapter', () => {
             });
         });
 
+        it('should resolve with stored item', () => {
+            const adapter = createClientStorageAdapter(defaultOptions);
+
+            expect(adapter.setItem(FOO_KEY, FOO_VALUE)).to.eventually.deep.equal(fooItem);
+        });
+
         context('when extra is passed', () => {
-            it('should store and resolve with item with extra', (done) => {
+            it('should store an item with extra', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
 
                 adapter.setItem(FOO_WITH_EXTRA_KEY, FOO_VALUE, FOO_EXTRA).then((item) => {
-                    expect(item).to.deep.eq(fooWithExtraItem);
                     expect(storageDummy.setItem)
                         .to.have.been.calledWith(FOO_WITH_EXTRA_KEY, fooWithExtraItemStringified)
                         .to.have.been.calledOnce;
@@ -121,6 +127,13 @@ describe('clientStorageAdapter', () => {
 
                     done();
                 });
+            });
+
+            it('should resolve with stored item with extra', () => {
+                const adapter = createClientStorageAdapter(defaultOptions);
+
+                expect(adapter.setItem(FOO_WITH_EXTRA_KEY, FOO_VALUE, FOO_EXTRA))
+                    .to.eventually.deep.equal(fooWithExtraItem);
             });
         });
     });
@@ -218,15 +231,21 @@ describe('clientStorageAdapter', () => {
             sandbox.restore();
         });
 
-        it('should store and resolve with extra', () => {
+        it('should store extra', () => {
+            const adapter = createClientStorageAdapter(defaultOptions);
+            const newExtra = { something: 'else' };
+            const stringifiedItemWithNewExtra = JSON.stringify(createItem(FOO_WITH_EXTRA_KEY, FOO_VALUE, newExtra));
+
+            adapter.setExtra(FOO_WITH_EXTRA_KEY, newExtra).then(() => {
+                expect(storageDummy.setItem).to.have.been.calledWith(FOO_WITH_EXTRA_KEY, stringifiedItemWithNewExtra);
+            });
+        });
+
+        it('should resolve with extra', () => {
             const adapter = createClientStorageAdapter(defaultOptions);
             const newExtra = { something: 'else' };
 
-            adapter.getExtra(FOO_WITH_EXTRA_KEY).then((extra) => {
-                expect(extra).to.deep.equal(FOO_EXTRA);
-
-                expect(adapter.setExtra(FOO_WITH_EXTRA_KEY, newExtra)).to.eventually.deep.equal(newExtra);
-            });
+            expect(adapter.setExtra(FOO_WITH_EXTRA_KEY, newExtra)).to.eventually.deep.equal(newExtra);
         });
 
         context('when item does not exist', () => {

--- a/test/unit/src/index.test.js
+++ b/test/unit/src/index.test.js
@@ -85,7 +85,7 @@ describe('clientStorageAdapter', () => {
         it('should return built key', () => {
             const adapter = createClientStorageAdapter(defaultOptions);
 
-            expect(adapter.buildKey('key')).to.eq('key');
+            expect(adapter.buildKey('key')).to.eventually.equal('key');
         });
     });
 

--- a/test/unit/src/index.test.js
+++ b/test/unit/src/index.test.js
@@ -318,7 +318,7 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when item exists', () => {
-            it('should remove that item returning true', () => {
+            it('should remove that item returning true', (done) => {
                 customHasOwnPropertyStub.onCall(0).returns(true);
                 customHasOwnPropertyStub.onCall(1).returns(false);
 
@@ -328,20 +328,23 @@ describe('clientStorageAdapter', () => {
                     { hasOwnProperty: customHasOwnPropertyStub }
                 );
                 const adapter = createClientStorageAdapter({ storage: customStorageDummy });
-                const result = adapter.removeItem(FOO_KEY);
 
-                expect(result).to.be.true;
-                expect(customHasOwnPropertyStub)
-                    .to.have.been.calledWith(FOO_KEY)
-                    .to.have.been.calledTwice;
-                expect(customStorageDummy.removeItem)
-                    .to.have.been.calledWith(FOO_KEY)
-                    .to.have.been.calledOnce;
+                adapter.removeItem(FOO_KEY).then((result) => {
+                    expect(result).to.be.true;
+                    expect(customHasOwnPropertyStub)
+                        .to.have.been.calledWith(FOO_KEY)
+                        .to.have.been.calledTwice;
+                    expect(customStorageDummy.removeItem)
+                        .to.have.been.calledWith(FOO_KEY)
+                        .to.have.been.calledOnce;
+
+                    done();
+                });
             });
         });
 
         context('when item does not exist', () => {
-            it('should not remove that item and return false', () => {
+            it('should not remove that item and return false', (done) => {
                 customHasOwnPropertyStub.returns(false);
 
                 const customStorageDummy = Object.assign(
@@ -350,13 +353,16 @@ describe('clientStorageAdapter', () => {
                     { hasOwnProperty: customHasOwnPropertyStub }
                 );
                 const adapter = createClientStorageAdapter({ storage: customStorageDummy });
-                const result = adapter.removeItem(NONEXISTENT_KEY);
 
-                expect(result).to.be.false;
-                expect(customHasOwnPropertyStub)
-                    .to.have.been.calledWith(NONEXISTENT_KEY)
-                    .to.have.been.calledOnce;
-                expect(storageDummy.removeItem).to.not.have.been.called;
+                adapter.removeItem(NONEXISTENT_KEY).then((result) => {
+                    expect(result).to.be.false;
+                    expect(customHasOwnPropertyStub)
+                        .to.have.been.calledWith(NONEXISTENT_KEY)
+                        .to.have.been.calledOnce;
+                    expect(storageDummy.removeItem).to.not.have.been.called;
+
+                    done();
+                });
             });
         });
     });

--- a/test/unit/src/index.test.js
+++ b/test/unit/src/index.test.js
@@ -280,24 +280,32 @@ describe('clientStorageAdapter', () => {
 
     describe('hasItem', () => {
         context('when item exists', () => {
-            it('should return true', () => {
+            it('should return true', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
 
-                expect(adapter.hasItem(FOO_KEY)).to.be.true;
-                expect(storageDummy.hasOwnProperty)
-                    .to.have.been.calledWith(FOO_KEY)
-                    .to.have.been.calledOnce;
+                adapter.hasItem(FOO_KEY).then((result) => {
+                    expect(result).to.be.true;
+                    expect(storageDummy.hasOwnProperty)
+                        .to.have.been.calledWith(FOO_KEY)
+                        .to.have.been.calledOnce;
+
+                    done();
+                });
             });
         });
 
         context('when item does not exist', () => {
-            it('should return false', () => {
+            it('should return false', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
 
-                expect(adapter.hasItem(NONEXISTENT_KEY)).to.be.false;
-                expect(storageDummy.hasOwnProperty)
-                    .to.have.been.calledWith(NONEXISTENT_KEY)
-                    .to.have.been.calledOnce;
+                adapter.hasItem(NONEXISTENT_KEY).then((result) => {
+                    expect(result).to.be.false;
+                    expect(storageDummy.hasOwnProperty)
+                        .to.have.been.calledWith(NONEXISTENT_KEY)
+                        .to.have.been.calledOnce;
+
+                    done();
+                });
             });
         });
     });

--- a/test/unit/src/index.test.js
+++ b/test/unit/src/index.test.js
@@ -82,7 +82,7 @@ describe('clientStorageAdapter', () => {
     });
 
     describe('buildKey', () => {
-        it('should return built key', () => {
+        it('should resolve with built key', () => {
             const adapter = createClientStorageAdapter(defaultOptions);
 
             expect(adapter.buildKey('key')).to.eventually.equal('key');
@@ -90,7 +90,7 @@ describe('clientStorageAdapter', () => {
     });
 
     describe('setItem', () => {
-        it('should store and return item', (done) => {
+        it('should store and resolve with item', (done) => {
             const adapter = createClientStorageAdapter(defaultOptions);
 
             adapter.setItem(FOO_KEY, FOO_VALUE).then((item) => {
@@ -107,7 +107,7 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when extra is passed', () => {
-            it('should store and return item with extra', (done) => {
+            it('should store and resolve with item with extra', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
 
                 adapter.setItem(FOO_WITH_EXTRA_KEY, FOO_VALUE, FOO_EXTRA).then((item) => {
@@ -135,7 +135,7 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when item exists', () => {
-            it('should return that item', (done) => {
+            it('should resolve with that item', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
 
                 adapter.getItem(FOO_KEY).then((item) => {
@@ -153,7 +153,7 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when item does not exist', () => {
-            it('should return undefined', (done) => {
+            it('should resolve with undefined', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
 
                 adapter.getItem(NONEXISTENT_KEY).then((item) => {
@@ -179,7 +179,7 @@ describe('clientStorageAdapter', () => {
             sandbox.restore();
         });
 
-        it('should add extra to existing one and return combined extra', () => {
+        it('should add extra to existing one and resolve with combined extra', () => {
             const addedExtra = { something: 'else' };
             const expectedCombinedExtra = { ...FOO_EXTRA, ...addedExtra };
             const adapter = createClientStorageAdapter(defaultOptions);
@@ -188,7 +188,7 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when item does not exist', () => {
-            it('should return undefined', () => {
+            it('should resolve with undefined', () => {
                 const adapter = createClientStorageAdapter(defaultOptions);
 
                 expect(adapter.addExtra(NONEXISTENT_KEY, FOO_EXTRA)).to.eventually.be.undefined;
@@ -196,7 +196,7 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when added extra contains properties of existing extra', () => {
-            it('should return extra with existing properties overwritten with new ones', () => {
+            it('should resolve with extra where existing properties are overwritten with new ones', () => {
                 const adapter = createClientStorageAdapter(defaultOptions);
                 const extraToAdd = { foo: 'entirely different foo extra' };
                 const expectedCombinedExtra = { ...FOO_EXTRA, ...extraToAdd };
@@ -218,7 +218,7 @@ describe('clientStorageAdapter', () => {
             sandbox.restore();
         });
 
-        it('should store and return extra', () => {
+        it('should store and resolve with extra', () => {
             const adapter = createClientStorageAdapter(defaultOptions);
             const newExtra = { something: 'else' };
 
@@ -230,7 +230,7 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when item does not exist', () => {
-            it('should return undefined', () => {
+            it('should resolve with undefined', () => {
                 const adapter = createClientStorageAdapter(defaultOptions);
 
                 expect(adapter.setExtra(NONEXISTENT_KEY, FOO_EXTRA)).to.eventually.be.undefined;
@@ -248,7 +248,7 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when item exists', () => {
-            it('should return extra', (done) => {
+            it('should resolve with extra', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
 
                 adapter.getExtra(FOO_WITH_EXTRA_KEY).then((extra) => {
@@ -263,7 +263,7 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when item does not exist', () => {
-            it('should return undefined', (done) => {
+            it('should resolve with undefined', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
 
                 adapter.getExtra(NONEXISTENT_KEY).then((extra) => {
@@ -280,7 +280,7 @@ describe('clientStorageAdapter', () => {
 
     describe('hasItem', () => {
         context('when item exists', () => {
-            it('should return true', (done) => {
+            it('should resolve with true', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
 
                 adapter.hasItem(FOO_KEY).then((result) => {
@@ -295,7 +295,7 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when item does not exist', () => {
-            it('should return false', (done) => {
+            it('should resolve with false', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
 
                 adapter.hasItem(NONEXISTENT_KEY).then((result) => {

--- a/test/unit/src/index.test.js
+++ b/test/unit/src/index.test.js
@@ -135,29 +135,35 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when item exists', () => {
-            it('should return that item', () => {
+            it('should return that item', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
-                const item = adapter.getItem(FOO_KEY);
 
-                expect(item).to.deep.eq(fooItem);
-                expect(storageDummy.getItem)
-                    .to.have.been.calledWith(FOO_KEY)
-                    .to.have.been.calledOnce;
-                expect(JSON.parse)
-                    .to.have.been.calledWith(fooItemStringified)
-                    .to.have.been.calledOnce;
+                adapter.getItem(FOO_KEY).then((item) => {
+                    expect(item).to.deep.eq(fooItem);
+                    expect(storageDummy.getItem)
+                        .to.have.been.calledWith(FOO_KEY)
+                        .to.have.been.calledOnce;
+                    expect(JSON.parse)
+                        .to.have.been.calledWith(fooItemStringified)
+                        .to.have.been.calledOnce;
+
+                    done();
+                });
             });
         });
 
         context('when item does not exist', () => {
-            it('should return undefined', () => {
+            it('should return undefined', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
-                const item = adapter.getItem(NONEXISTENT_KEY);
 
-                expect(item).to.be.undefined;
-                expect(storageDummy.getItem)
-                    .to.have.been.calledWith(NONEXISTENT_KEY)
-                    .to.have.been.calledOnce;
+                adapter.getItem(NONEXISTENT_KEY).then((item) => {
+                    expect(item).to.be.undefined;
+                    expect(storageDummy.getItem)
+                        .to.have.been.calledWith(NONEXISTENT_KEY)
+                        .to.have.been.calledOnce;
+
+                    done();
+                });
             });
         });
     });
@@ -214,12 +220,13 @@ describe('clientStorageAdapter', () => {
 
         it('should store and return extra', () => {
             const adapter = createClientStorageAdapter(defaultOptions);
-            const currentExtra = adapter.getExtra(FOO_WITH_EXTRA_KEY);
             const newExtra = { something: 'else' };
 
-            expect(adapter.setExtra(FOO_WITH_EXTRA_KEY, newExtra)).to.eventually.deep.equal(newExtra);
+            adapter.getExtra(FOO_WITH_EXTRA_KEY).then((extra) => {
+                expect(extra).to.deep.equal(FOO_EXTRA);
 
-            expect(currentExtra).to.deep.equal(FOO_EXTRA);
+                expect(adapter.setExtra(FOO_WITH_EXTRA_KEY, newExtra)).to.eventually.deep.equal(newExtra);
+            });
         });
 
         context('when item does not exist', () => {
@@ -241,26 +248,32 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when item exists', () => {
-            it('should return extra', () => {
+            it('should return extra', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
-                const extra = adapter.getExtra(FOO_WITH_EXTRA_KEY);
 
-                expect(extra).to.deep.equal(FOO_EXTRA);
-                expect(storageDummy.getItem)
-                    .to.have.been.calledWith(FOO_WITH_EXTRA_KEY)
-                    .to.have.been.calledOnce;
+                adapter.getExtra(FOO_WITH_EXTRA_KEY).then((extra) => {
+                    expect(extra).to.deep.equal(FOO_EXTRA);
+                    expect(storageDummy.getItem)
+                        .to.have.been.calledWith(FOO_WITH_EXTRA_KEY)
+                        .to.have.been.calledOnce;
+
+                    done();
+                });
             });
         });
 
         context('when item does not exist', () => {
-            it('should return undefined', () => {
+            it('should return undefined', (done) => {
                 const adapter = createClientStorageAdapter(defaultOptions);
-                const extra = adapter.getExtra(NONEXISTENT_KEY);
 
-                expect(extra).to.be.undefined;
-                expect(storageDummy.getItem)
-                    .to.have.been.calledWith(NONEXISTENT_KEY)
-                    .to.have.been.calledOnce;
+                adapter.getExtra(NONEXISTENT_KEY).then((extra) => {
+                    expect(extra).to.be.undefined;
+                    expect(storageDummy.getItem)
+                        .to.have.been.calledWith(NONEXISTENT_KEY)
+                        .to.have.been.calledOnce;
+
+                    done();
+                });
             });
         });
     });

--- a/test/unit/src/index.test.js
+++ b/test/unit/src/index.test.js
@@ -318,7 +318,7 @@ describe('clientStorageAdapter', () => {
         });
 
         context('when item exists', () => {
-            it('should remove that item returning true', (done) => {
+            it('should remove that item', (done) => {
                 customHasOwnPropertyStub.onCall(0).returns(true);
                 customHasOwnPropertyStub.onCall(1).returns(false);
 
@@ -329,8 +329,7 @@ describe('clientStorageAdapter', () => {
                 );
                 const adapter = createClientStorageAdapter({ storage: customStorageDummy });
 
-                adapter.removeItem(FOO_KEY).then((result) => {
-                    expect(result).to.be.true;
+                adapter.removeItem(FOO_KEY).then(() => {
                     expect(customHasOwnPropertyStub)
                         .to.have.been.calledWith(FOO_KEY)
                         .to.have.been.calledTwice;
@@ -341,10 +340,24 @@ describe('clientStorageAdapter', () => {
                     done();
                 });
             });
+
+            it('should resolve with true', () => {
+                customHasOwnPropertyStub.onCall(0).returns(true);
+                customHasOwnPropertyStub.onCall(1).returns(false);
+
+                const customStorageDummy = Object.assign(
+                    {},
+                    storageDummy,
+                    { hasOwnProperty: customHasOwnPropertyStub }
+                );
+                const adapter = createClientStorageAdapter({ storage: customStorageDummy });
+
+                expect(adapter.removeItem(FOO_KEY)).to.eventually.be.true;
+            });
         });
 
         context('when item does not exist', () => {
-            it('should not remove that item and return false', (done) => {
+            it('should not remove that item', (done) => {
                 customHasOwnPropertyStub.returns(false);
 
                 const customStorageDummy = Object.assign(
@@ -354,8 +367,7 @@ describe('clientStorageAdapter', () => {
                 );
                 const adapter = createClientStorageAdapter({ storage: customStorageDummy });
 
-                adapter.removeItem(NONEXISTENT_KEY).then((result) => {
-                    expect(result).to.be.false;
+                adapter.removeItem(NONEXISTENT_KEY).then(() => {
                     expect(customHasOwnPropertyStub)
                         .to.have.been.calledWith(NONEXISTENT_KEY)
                         .to.have.been.calledOnce;
@@ -363,6 +375,19 @@ describe('clientStorageAdapter', () => {
 
                     done();
                 });
+            });
+
+            it('should resolve with false', () => {
+                customHasOwnPropertyStub.returns(false);
+
+                const customStorageDummy = Object.assign(
+                    {},
+                    storageDummy,
+                    { hasOwnProperty: customHasOwnPropertyStub }
+                );
+                const adapter = createClientStorageAdapter({ storage: customStorageDummy });
+
+                expect(adapter.removeItem(NONEXISTENT_KEY)).to.eventually.be.false;
             });
         });
     });

--- a/test/unit/src/index.test.js
+++ b/test/unit/src/index.test.js
@@ -90,31 +90,37 @@ describe('clientStorageAdapter', () => {
     });
 
     describe('setItem', () => {
-        it('should store and return item', () => {
+        it('should store and return item', (done) => {
             const adapter = createClientStorageAdapter(defaultOptions);
-            const item = adapter.setItem(FOO_KEY, FOO_VALUE);
 
-            expect(item).to.deep.eq(fooItem);
-            expect(storageDummy.setItem)
-                .to.have.been.calledWith(FOO_KEY, fooItemStringified)
-                .to.have.been.calledOnce;
-            expect(JSON.stringify)
-                .to.have.been.calledWith(item)
-                .to.have.been.calledOnce;
-        });
-
-        context('when extra is passed', () => {
-            it('should store and return item with extra', () => {
-                const adapter = createClientStorageAdapter(defaultOptions);
-                const item = adapter.setItem(FOO_WITH_EXTRA_KEY, FOO_VALUE, FOO_EXTRA);
-
-                expect(item).to.deep.eq(fooWithExtraItem);
+            adapter.setItem(FOO_KEY, FOO_VALUE).then((item) => {
+                expect(item).to.deep.eq(fooItem);
                 expect(storageDummy.setItem)
-                    .to.have.been.calledWith(FOO_WITH_EXTRA_KEY, fooWithExtraItemStringified)
+                    .to.have.been.calledWith(FOO_KEY, fooItemStringified)
                     .to.have.been.calledOnce;
                 expect(JSON.stringify)
                     .to.have.been.calledWith(item)
                     .to.have.been.calledOnce;
+
+                done();
+            });
+        });
+
+        context('when extra is passed', () => {
+            it('should store and return item with extra', (done) => {
+                const adapter = createClientStorageAdapter(defaultOptions);
+
+                adapter.setItem(FOO_WITH_EXTRA_KEY, FOO_VALUE, FOO_EXTRA).then((item) => {
+                    expect(item).to.deep.eq(fooWithExtraItem);
+                    expect(storageDummy.setItem)
+                        .to.have.been.calledWith(FOO_WITH_EXTRA_KEY, fooWithExtraItemStringified)
+                        .to.have.been.calledOnce;
+                    expect(JSON.stringify)
+                        .to.have.been.calledWith(item)
+                        .to.have.been.calledOnce;
+
+                    done();
+                });
             });
         });
     });
@@ -171,17 +177,15 @@ describe('clientStorageAdapter', () => {
             const addedExtra = { something: 'else' };
             const expectedCombinedExtra = { ...FOO_EXTRA, ...addedExtra };
             const adapter = createClientStorageAdapter(defaultOptions);
-            const returnedExtra = adapter.addExtra(FOO_WITH_EXTRA_KEY, addedExtra);
 
-            expect(returnedExtra).to.deep.equal(expectedCombinedExtra);
+            expect(adapter.addExtra(FOO_WITH_EXTRA_KEY, addedExtra)).to.eventually.deep.equal(expectedCombinedExtra);
         });
 
         context('when item does not exist', () => {
             it('should return undefined', () => {
                 const adapter = createClientStorageAdapter(defaultOptions);
-                const addedExtra = adapter.addExtra(NONEXISTENT_KEY, FOO_EXTRA);
 
-                expect(addedExtra).to.be.undefined;
+                expect(adapter.addExtra(NONEXISTENT_KEY, FOO_EXTRA)).to.eventually.be.undefined;
             });
         });
 
@@ -189,10 +193,10 @@ describe('clientStorageAdapter', () => {
             it('should return extra with existing properties overwritten with new ones', () => {
                 const adapter = createClientStorageAdapter(defaultOptions);
                 const extraToAdd = { foo: 'entirely different foo extra' };
-                const returnedExtra = adapter.addExtra(FOO_WITH_EXTRA_KEY, extraToAdd);
                 const expectedCombinedExtra = { ...FOO_EXTRA, ...extraToAdd };
 
-                expect(returnedExtra).to.deep.equal(expectedCombinedExtra);
+                expect(adapter.addExtra(FOO_WITH_EXTRA_KEY, extraToAdd))
+                    .to.eventually.deep.equal(expectedCombinedExtra);
             });
         });
     });
@@ -212,18 +216,17 @@ describe('clientStorageAdapter', () => {
             const adapter = createClientStorageAdapter(defaultOptions);
             const currentExtra = adapter.getExtra(FOO_WITH_EXTRA_KEY);
             const newExtra = { something: 'else' };
-            const returnedExtra = adapter.setExtra(FOO_WITH_EXTRA_KEY, newExtra);
+
+            expect(adapter.setExtra(FOO_WITH_EXTRA_KEY, newExtra)).to.eventually.deep.equal(newExtra);
 
             expect(currentExtra).to.deep.equal(FOO_EXTRA);
-            expect(returnedExtra).to.deep.equal(newExtra);
         });
 
         context('when item does not exist', () => {
             it('should return undefined', () => {
                 const adapter = createClientStorageAdapter(defaultOptions);
-                const extra = adapter.setExtra(NONEXISTENT_KEY, FOO_EXTRA);
 
-                expect(extra).to.be.undefined;
+                expect(adapter.setExtra(NONEXISTENT_KEY, FOO_EXTRA)).to.eventually.be.undefined;
             });
         });
     });


### PR DESCRIPTION
### Why?

This is a first step to bringing adapters that require asynchronous IO operations (e.g. for mongo). Such adapters will have to be promised based. So, for the API to be polymorphic, all other adapters need to be promisified as well.